### PR TITLE
build_leveldown.sh script doesn't work on Linux.

### DIFF
--- a/src/android/build_leveldown.sh
+++ b/src/android/build_leveldown.sh
@@ -17,7 +17,7 @@ if [ $# -eq 1 ]
 then
   rm -rf jxcore-binaries/
   mkdir jxcore-binaries/
-  cp -R $1/ jxcore-binaries/
+  cp -R $1/* jxcore-binaries/
   rm jxcore-binaries/*_x64.a
 else
   LOG $RED_COLOR "You should provide the path for JXcore Android binaries"


### PR DESCRIPTION
Is a trivial fix. Tested on macOS 10.11.6 and Ubuntu 16.04.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/jxcore-cordova/7)

<!-- Reviewable:end -->

<!---
@huboard:{"order":4.4275900565703954e-16,"milestone_order":7,"custom_state":""}
-->
